### PR TITLE
Driver Network Table

### DIFF
--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -346,6 +346,6 @@ void RobotContainer::ReportSelectedAuto () {
         name = m_DashboardAutoChooser.GetDefaultName();
     }
 
-    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable("Driving");
+    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable(NetTabs::DriveTeamTable);
     drivetable->PutString("Robot Sees AutoMode:", name);
 }

--- a/src/main/cpp/subsystems/Climb.cpp
+++ b/src/main/cpp/subsystems/Climb.cpp
@@ -12,7 +12,7 @@
 Climb::Climb () {}
 
 void Climb::Periodic () {
-    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable("Driving");
+    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable(NetTabs::DriveTeamTable);
     drivetable->PutBoolean("Winch Locked", m_IsWinchLocked);
     drivetable->PutBoolean("Climb Piston Extended", m_IsPistonExtended);
 }

--- a/src/main/cpp/subsystems/Shooter.cpp
+++ b/src/main/cpp/subsystems/Shooter.cpp
@@ -169,7 +169,7 @@ void Shooter::SetLimelightLight (bool on) {
 }
 
 void Shooter::TrackingPeriodic (TrackingMode mode) {
-    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable("Driving");
+    auto drivetable = nt::NetworkTableInstance::GetDefault().GetTable(NetTabs::DriveTeamTable);
 
     if (mode == TrackingMode::CameraTracking) {
         double speed = 0;

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -1,5 +1,9 @@
 #pragma once
 
+namespace NetTabs {
+    const std::string DriveTeamTable = "Driving";
+}
+
 namespace ConfigFiles {
     const std::string ConfigFile     = "config.toml";
     const std::string AutoConfigFile = "auto.toml";


### PR DESCRIPTION
From rationale commit:

Currently we use Shuffleboard for our dashboard on the driver station. The Driving network table contains all the data that we can push (which does not include from the SendableChooser and the Limelight camera feed) that the drive team needs to run a match. This table should be reserved for this purpose alone, as currently we simply push any data we may need during testing with SmartDashboard. As I understand, Shuffleboard allows us to use data from other tables on the same page as the ones specifically for it, and we can set up a nice view that will remain persistent between reboots of the robot and not be cluttered with data the drive team does not need.